### PR TITLE
Add the gulpplugin keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "handlebars",
     "hbs",
     "json",
-    "gulp"
+    "gulp",
+    "gulpplugin"
   ],
   "author": "Phil Mander",
   "license": "MIT",


### PR DESCRIPTION
This keyword should make the plugin appear on http://gulpjs.com/plugins/
